### PR TITLE
Fix for when component_path has been set with a string

### DIFF
--- a/lib/kookaburra/ui_driver/ui_component.rb
+++ b/lib/kookaburra/ui_driver/ui_component.rb
@@ -20,7 +20,7 @@ module Kookaburra
         when Symbol
           alias_method :component_path, path
         else
-          define_method(:component_path) { path }
+          define_method(:component_path) { |*args| path }
         end
       end
 


### PR DESCRIPTION
This is a fix for when the component_path is not a symbol, but a String e.g.:

```
class MyApplication::Kookaburra::UiDriver::SignInScreen < Kookaburra::UIDriver::UIComponent

  component_locator '#login-form'
  component_path '/users/sign_in'

  # ...
end
```
# navigate_to will indirectly call component_path with an argument whereas the generated component_path doesn't allow arguments.

I didn't add tests because I could not find a nice place to add it. I considered `ui_driver_test.rb`, but there was too much stubbing going on for this too work. I'm still not confident enough with the code to know what exactly is going on.
